### PR TITLE
Only handle requests in _{spec,test}.rb files

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
@@ -26,7 +26,7 @@ module RubyLsp
         ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))
       end
       def create_code_lens_listener(uri, emitter, message_queue)
-        return nil unless uri.to_standardized_path&.end_with?("_test.rb") || uri.to_standardized_path&.end_with?("_spec.rb")
+        return unless uri.to_standardized_path&.end_with?("_test.rb") || uri.to_standardized_path&.end_with?("_spec.rb")
 
         CodeLens.new(uri, emitter, message_queue)
       end

--- a/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
@@ -26,6 +26,8 @@ module RubyLsp
         ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))
       end
       def create_code_lens_listener(uri, emitter, message_queue)
+        return nil unless uri.to_standardized_path&.end_with?("_test.rb") || uri.to_standardized_path&.end_with?("_spec.rb")
+
         CodeLens.new(uri, emitter, message_queue)
       end
 

--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -17,7 +17,8 @@ module RubyLsp
       sig { params(uri: URI::Generic, dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
       def initialize(uri, dispatcher, message_queue)
         @_response = T.let([], ResponseType)
-        @path = T.let(T.must(uri.to_standardized_path), String) # Listener is only initialized if uri.to_standardized_path is valid
+        # Listener is only initialized if uri.to_standardized_path is valid
+        @path = T.let(T.must(uri.to_standardized_path), String) 
         dispatcher.register(self, :on_call_node_enter)
 
         @base_command = T.let(

--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -17,7 +17,7 @@ module RubyLsp
       sig { params(uri: URI::Generic, dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
       def initialize(uri, dispatcher, message_queue)
         @_response = T.let([], ResponseType)
-        @path = T.let(uri.to_standardized_path, T.nilable(String))
+        @path = T.let(T.must(uri.to_standardized_path), String) # Listener is only initialized if uri.to_standardized_path is valid
         dispatcher.register(self, :on_call_node_enter)
 
         @base_command = T.let(
@@ -78,8 +78,6 @@ module RubyLsp
 
       sig { params(node: Prism::Node, name: String, kind: Symbol).void }
       def add_test_code_lens(node, name:, kind:)
-        return unless @path
-
         line_number = node.location.start_line
         command = "#{@base_command} #{@path}:#{line_number}"
 

--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -18,7 +18,7 @@ module RubyLsp
       def initialize(uri, dispatcher, message_queue)
         @_response = T.let([], ResponseType)
         # Listener is only initialized if uri.to_standardized_path is valid
-        @path = T.let(T.must(uri.to_standardized_path), String) 
+        @path = T.let(T.must(uri.to_standardized_path), String)
         dispatcher.register(self, :on_call_node_enter)
 
         @base_command = T.let(


### PR DESCRIPTION
Ran into this issue today where I saw rspec markers in a non-spec file: 

<img width="677" alt="Screenshot 2023-10-28 at 21 43 51" src="https://github.com/st0012/ruby-lsp-rspec/assets/3893573/0b0c6976-0db9-4962-a374-0c9281d5e564">

This PR fixes that behaviour by restricting the codelens listener to only listen on files that are named `_test.rb` or `_spec.rb`. 

## Potential Issues

Rspec's default file pattern is `_spec.rb`, but that can be [configured](https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration#pattern-instance_method). 

I vaguely remember coming across codebases that use `_test.rb` for specs, hence the added pattern. This can backfire if people use both rspec & minitest. Minitest has a spec syntax too, so `ruby-lsp-rspec` will end up creating incorrect markers on minitest files. Won't affect minitest-only users since I assume they won't have this addon installed. 

I suspect the only accurate way to fix these issues would be to get the exact value of rspec's file pattern - either through static analysis, or by having a configuration option passed in. Doubt that either of these options are easy to do, but open to suggestions!

## Other approaches

My first instinct was to improve how `context` is detected, by ignoring usages like `context.foo`. Thought about this a bit more, and dropped it because even a non-test file _could_ have usages like `context "foo" {}` if it was using a non-rspec DSL.