### PR TITLE
Add support for "specify" and "example" declarations

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -43,11 +43,11 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
-        message_value = node.message
-        if message_value == "it"
+        case node.message
+        when "example", "it", "specify"
           name = generate_name(node)
           add_test_code_lens(node, name: name, kind: :example)
-        elsif message_value == "describe" || message_value == "context"
+        when "context", "describe"
           return if node.receiver && node.receiver.name.to_s != "RSpec"
 
           name = generate_name(node)

--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -75,11 +75,15 @@ RSpec.describe RubyLsp::RSpec do
     end
   end
 
-  it "recognizes different it declaration" do
+  it "recognizes different example, it, and specify declarations" do
     store.set(uri: uri, source: <<~RUBY, version: 1)
       RSpec.describe Foo do
         it { do_something }
-        it var do
+        it var1 do
+          do_something
+        end
+        specify { do_something }
+        example var2 do
           do_something
         end
       end
@@ -98,13 +102,15 @@ RSpec.describe RubyLsp::RSpec do
     expect(response.error).to(be_nil)
 
     response = response.response
-    expect(response.count).to eq(9)
+    expect(response.count).to eq(15)
 
     expect(response[3].command.arguments[1]).to eq("<unnamed>")
-    expect(response[6].command.arguments[1]).to eq("<var>")
+    expect(response[6].command.arguments[1]).to eq("<var1>")
+    expect(response[9].command.arguments[1]).to eq("<unnamed>")
+    expect(response[12].command.arguments[1]).to eq("<var2>")
   end
 
-  it "recognizes different describe declaration" do
+  it "recognizes different context and describe declarations" do
     store.set(uri: uri, source: <<~RUBY, version: 1)
       RSpec.describe(Foo::Bar) do
       end
@@ -112,13 +118,13 @@ RSpec.describe RubyLsp::RSpec do
       RSpec.describe Foo::Bar do
       end
 
-      describe(Foo) do
+      context(Foo) do
       end
 
       describe Foo do
       end
 
-      describe "Foo" do
+      context "Foo" do
       end
 
       describe var do


### PR DESCRIPTION
This patch adds support for `specify` and `example` declarations, which are aliases for `it` in RSpec.

This is useful for people (like me) who prefer to use `specify` or `example` over `it` in their RSpec tests.

RSpec method aliases are defined here:
https://github.com/rspec/rspec-core/blob/80bdf067758678ee32191c04f4d479031e20606d/lib/rspec/core/example_group.rb#L53-L67

Close https://github.com/st0012/ruby-lsp-rspec/issues/11