### PR TITLE
Support CodeLens hierarchy by adding grouping info

### DIFF
--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe RubyLsp::RSpec do
     response = response.response
     expect(response.count).to eq(9)
 
-    expect(response[0].data).to eq({ type: "test", kind: :group })
-    expect(response[1].data).to eq({ type: "test_in_terminal", kind: :group })
-    expect(response[2].data).to eq({ type: "debug", kind: :group })
+    expect(response[0].data).to eq({ type: "test", kind: :group, group_id: nil, id: 1 })
+    expect(response[1].data).to eq({ type: "test_in_terminal", kind: :group, group_id: nil, id: 1 })
+    expect(response[2].data).to eq({ type: "debug", kind: :group, group_id: nil, id: 1 })
 
     0.upto(2) do |i|
       expect(response[i].command.arguments).to eq([
@@ -48,9 +48,9 @@ RSpec.describe RubyLsp::RSpec do
       ])
     end
 
-    expect(response[3].data).to eq({ type: "test", kind: :group })
-    expect(response[4].data).to eq({ type: "test_in_terminal", kind: :group })
-    expect(response[5].data).to eq({ type: "debug", kind: :group })
+    expect(response[3].data).to eq({ type: "test", kind: :group, group_id: 1, id: 2 })
+    expect(response[4].data).to eq({ type: "test_in_terminal", kind: :group, group_id: 1, id: 2 })
+    expect(response[5].data).to eq({ type: "debug", kind: :group, group_id: 1, id: 2 })
 
     3.upto(5) do |i|
       expect(response[i].command.arguments).to eq([
@@ -61,9 +61,9 @@ RSpec.describe RubyLsp::RSpec do
       ])
     end
 
-    expect(response[6].data).to eq({ type: "test", kind: :example })
-    expect(response[7].data).to eq({ type: "test_in_terminal", kind: :example })
-    expect(response[8].data).to eq({ type: "debug", kind: :example })
+    expect(response[6].data).to eq({ type: "test", kind: :example, group_id: 2 })
+    expect(response[7].data).to eq({ type: "test_in_terminal", kind: :example, group_id: 2 })
+    expect(response[8].data).to eq({ type: "debug", kind: :example, group_id: 2 })
 
     6.upto(8) do |i|
       expect(response[i].command.arguments).to eq([


### PR DESCRIPTION
Currently, RSpec tests with more than 2 levels of nesting aren't displayed correctly in the test explorer.

For example, this [addon's tests](https://github.com/st0012/ruby-lsp-rspec/blob/main/spec/ruby_lsp_rspec_spec.rb) are displayed like this atm:

<img width="50%" alt="Screenshot 2023-11-29 at 12 27 20" src="https://github.com/st0012/ruby-lsp-rspec/assets/5079556/82638c07-7a1e-431f-ab56-790beec9e16e">


But once https://github.com/Shopify/vscode-ruby-lsp/pull/914 is released, this PR will provide the additional metadata to help the extension build the correct hierarchy:

<img width="50%" alt="Screenshot 2023-11-29 at 12 27 20" src="https://github.com/st0012/ruby-lsp-rspec/assets/5079556/b619abd1-b6b2-4cd1-bf10-1495113fa905">

This is safe to merge before the extension release because the additional metadata will just be ignored.


