### PR TITLE
Handle repo with both `bundler` and `/bin/rspec`

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -25,17 +25,15 @@ module RubyLsp
 
         @base_command = T.let(
           begin
-            cmd = if File.exist?(File.join(Dir.pwd, "bin", "rspec"))
-              "bin/rspec"
-            else
-              "rspec"
+            if File.exist?(File.join(Dir.pwd, "bin", "rspec"))
+              return "bin/rspec"
             end
 
             if File.exist?("Gemfile.lock")
-              "bundle exec #{cmd}"
-            else
-              cmd
+              "bundle exec rspec"
             end
+
+            "rspec"
           end,
           String,
         )


### PR DESCRIPTION
In a repo I work in we have we have both gemfile and binfile for rspec.

The bin file is using spring to speed up loading.

This means we try and run `bundle exec ./bin/rspec` which hangs until timeout :point_down: when attempting to run tests.

```
bundle exec bin/rspec /somespec...       
^C^C/workspaces/heaven/vendor/gems/ruby/3.1.0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:60:in `rescue in kernel_load': Interrupt
TIMEOUT
```

This change tweaks the logic to return which ever is found first, rather than combining them.