### PR TITLE
Support go to `let`, `let!`, `subject`, and `subject!` definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     diff-lcs (1.5.1)
     erubi (1.13.0)
     io-console (0.7.2)
-    irb (1.14.0)
+    irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.2)
@@ -126,4 +126,4 @@ DEPENDENCIES
   tapioca (~> 0.11)
 
 BUNDLED WITH
-   2.5.4
+   2.5.11

--- a/lib/ruby_lsp/ruby_lsp_rspec/definition.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/definition.rb
@@ -1,0 +1,55 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module RSpec
+    class Definition
+      extend T::Sig
+
+      include ::RubyLsp::Requests::Support::Common
+
+      sig do
+        params(
+          response_builder: ResponseBuilders::CollectionResponseBuilder[T.any(
+            Interface::Location,
+            Interface::LocationLink,
+          )],
+          uri: URI::Generic,
+          node_context: NodeContext,
+          index: RubyIndexer::Index,
+          dispatcher: Prism::Dispatcher,
+        ).void
+      end
+      def initialize(response_builder, uri, node_context, index, dispatcher)
+        @response_builder = response_builder
+        @uri = uri
+        @node_context = node_context
+        @index = index
+        dispatcher.register(self, :on_call_node_enter)
+      end
+
+      sig { params(node: Prism::CallNode).void }
+      def on_call_node_enter(node)
+        message = node.message
+        return unless message
+
+        return if @node_context.locals_for_scope.include?(message)
+
+        entries = @index[message]
+        return unless entries
+        return if entries.empty?
+
+        entries.each do |entry|
+          # Technically, let can be defined in a different file, but we're not going to handle that case yet
+          next unless entry.file_path == @uri.to_standardized_path
+
+          @response_builder << Interface::LocationLink.new(
+            target_uri: URI::Generic.from_path(path: entry.file_path).to_s,
+            target_range: range_from_location(entry.location),
+            target_selection_range: range_from_location(entry.name_location),
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/ruby_lsp_rspec/indexing_enhancement.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/indexing_enhancement.rb
@@ -1,0 +1,93 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module RSpec
+    class IndexingEnhancement
+      extend T::Sig
+      include RubyIndexer::Enhancement
+
+      sig do
+        override.params(
+          index: RubyIndexer::Index,
+          owner: T.nilable(RubyIndexer::Entry::Namespace),
+          node: Prism::CallNode,
+          file_path: String,
+        ).void
+      end
+      def on_call_node(index, owner, node, file_path)
+        return if node.receiver
+
+        name = node.name
+
+        case name
+        when :let, :let!
+          block_node = node.block
+          return unless block_node
+
+          arguments = node.arguments
+          return unless arguments
+
+          return if arguments.arguments.count != 1
+
+          method_name_node = T.must(arguments.arguments.first)
+
+          method_name = case method_name_node
+          when Prism::StringNode
+            method_name_node.slice
+          when Prism::SymbolNode
+            method_name_node.unescaped
+          end
+
+          return unless method_name
+
+          index.add(RubyIndexer::Entry::Method.new(
+            method_name,
+            file_path,
+            block_node.location,
+            block_node.location,
+            nil,
+            index.configuration.encoding,
+            [RubyIndexer::Entry::Signature.new([])],
+            RubyIndexer::Entry::Visibility::PUBLIC,
+            owner,
+          ))
+        when :subject, :subject!
+          block_node = node.block
+          return unless block_node
+
+          arguments = node.arguments
+
+          if arguments && arguments.arguments.count == 1
+            method_name_node = T.must(arguments.arguments.first)
+          end
+
+          method_name = if method_name_node
+            case method_name_node
+            when Prism::StringNode
+              method_name_node.slice
+            when Prism::SymbolNode
+              method_name_node.unescaped
+            end
+          else
+            "subject"
+          end
+
+          return unless method_name
+
+          index.add(RubyIndexer::Entry::Method.new(
+            method_name,
+            file_path,
+            block_node.location,
+            block_node.location,
+            nil,
+            index.configuration.encoding,
+            [RubyIndexer::Entry::Signature.new([])],
+            RubyIndexer::Entry::Visibility::PUBLIC,
+            owner,
+          ))
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -1,10 +1,211 @@
 # typed: false
 # frozen_string_literal: true
 
+require "tempfile"
+
 RSpec.describe RubyLsp::RSpec do
   include RubyLsp::TestHelper
 
   let(:uri) { URI("file:///fake_spec.rb") }
+
+  describe "definition" do
+    it "finds the subject declaration" do
+      source = <<~RUBY
+        RSpec.describe Foo do
+          subject { 1 }
+
+          it "does something" do
+            subject
+            foo(subject)
+          end
+        end
+      RUBY
+
+      tempfile = Tempfile.new
+      tempfile.write(source)
+      tempfile.close
+      uri = URI(tempfile.path)
+
+      with_server(source, uri) do |server, uri|
+        index = server.instance_variable_get(:@global_state).index
+        index.index_single(RubyIndexer::IndexablePath.new(nil, tempfile.path))
+        server.process_message(
+          {
+            id: 1,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 4, character: 4 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(1)
+        expect(response[0].target_uri).to eq(URI::Generic.from_path(path: tempfile.path).to_s)
+        range = response[0].target_range.attributes
+        range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+        expect(range_hash).to eq(
+          start: { line: 1, character: 10 },
+          end: { line: 1, character: 15 },
+        )
+
+        server.process_message(
+          {
+            id: 2,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 5, character: 9 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(1)
+        expect(response[0].target_uri).to eq(URI::Generic.from_path(path: tempfile.path).to_s)
+        range = response[0].target_range.attributes
+        range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+        expect(range_hash).to eq(
+          start: { line: 1, character: 10 },
+          end: { line: 1, character: 15 },
+        )
+      end
+    ensure
+      tempfile&.unlink
+    end
+
+    it "finds named subject declaration" do
+      source = <<~RUBY
+        RSpec.describe Foo do
+          subject(:variable) { 1 }
+
+          it "does something" do
+            subject
+            foo(variable)
+          end
+        end
+      RUBY
+
+      tempfile = Tempfile.new
+      tempfile.write(source)
+      tempfile.close
+      uri = URI(tempfile.path)
+
+      with_server(source, uri) do |server, uri|
+        index = server.instance_variable_get(:@global_state).index
+        index.index_single(RubyIndexer::IndexablePath.new(nil, tempfile.path))
+        server.process_message(
+          {
+            id: 1,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 4, character: 4 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(0)
+
+        server.process_message(
+          {
+            id: 2,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 5, character: 9 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(1)
+        expect(response[0].target_uri).to eq(URI::Generic.from_path(path: tempfile.path).to_s)
+        range = response[0].target_range.attributes
+        range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+        expect(range_hash).to eq(
+          start: { line: 1, character: 21 },
+          end: { line: 1, character: 26 },
+        )
+      end
+    ensure
+      tempfile&.unlink
+    end
+
+    it "finds the let declaration" do
+      source = <<~RUBY
+        RSpec.describe Foo do
+          let(:variable) { 1 }
+
+          it "does something" do
+            variable
+            foo(variable)
+          end
+        end
+      RUBY
+
+      tempfile = Tempfile.new
+      tempfile.write(source)
+      tempfile.close
+      uri = URI(tempfile.path)
+
+      with_server(source, uri) do |server, uri|
+        index = server.instance_variable_get(:@global_state).index
+        index.index_single(RubyIndexer::IndexablePath.new(nil, tempfile.path))
+        server.process_message(
+          {
+            id: 1,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 4, character: 4 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(1)
+        expect(response[0].target_uri).to eq(URI::Generic.from_path(path: tempfile.path).to_s)
+        range = response[0].target_range.attributes
+        range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+        expect(range_hash).to eq(
+          start: { line: 1, character: 17 },
+          end: { line: 1, character: 22 },
+        )
+
+        server.process_message(
+          {
+            id: 2,
+            method: "textDocument/definition",
+            params: {
+              textDocument: { uri: uri },
+              position: { line: 5, character: 9 },
+            },
+          },
+        )
+
+        response = server.pop_response.response
+
+        expect(response.count).to eq(1)
+        expect(response[0].target_uri).to eq(URI::Generic.from_path(path: tempfile.path).to_s)
+        range = response[0].target_range.attributes
+        range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+        expect(range_hash).to eq(
+          start: { line: 1, character: 17 },
+          end: { line: 1, character: 22 },
+        )
+      end
+    ensure
+      tempfile&.unlink
+    end
+  end
 
   describe "document symbol" do
     it "generates correct document symbols" do


### PR DESCRIPTION

https://github.com/user-attachments/assets/edb4e8cc-4740-492a-a388-a708e18e74b2

This is a naive implementation that lists all definitions from the same file. 

To better implement this, we need to create the `RSpec::ExampleGroups` class structures, add the declarations as its methods, and look up the definition based on the example's context.