### PR TITLE
Give anonymous examples unique names

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -21,6 +21,7 @@ module RubyLsp
         @path = T.let(T.must(uri.to_standardized_path), String)
         @group_id = T.let(1, Integer)
         @group_id_stack = T.let([], T::Array[Integer])
+        @anonymous_example_count = T.let(0, Integer)
         dispatcher.register(self, :on_call_node_enter, :on_call_node_leave)
 
         @base_command = T.let(
@@ -93,7 +94,8 @@ module RubyLsp
             argument.slice
           end
         else
-          "<unnamed>"
+          @anonymous_example_count += 1
+          "<unnamed-#{@anonymous_example_count}>"
         end
       end
 

--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -380,9 +380,9 @@ RSpec.describe RubyLsp::RSpec do
 
         expect(response.count).to eq(15)
 
-        expect(response[3].command.arguments[1]).to eq("<unnamed>")
+        expect(response[3].command.arguments[1]).to eq("<unnamed-1>")
         expect(response[6].command.arguments[1]).to eq("<var1>")
-        expect(response[9].command.arguments[1]).to eq("<unnamed>")
+        expect(response[9].command.arguments[1]).to eq("<unnamed-2>")
         expect(response[12].command.arguments[1]).to eq("<var2>")
       end
     end


### PR DESCRIPTION
Otherwise, they won't be displayed in VS Code's Test Explorer correctly.

Fixes #35 