### PR TITLE
Support Non-ASCII characters

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/document_symbol.rb
@@ -74,7 +74,7 @@ module RubyLsp
 
         case argument
         when Prism::StringNode
-          argument.content.dump
+          argument.unescaped
         when Prism::CallNode
           "<#{argument.name}>"
         when nil

--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -284,8 +284,7 @@ RSpec.describe RubyLsp::RSpec do
         expect(foo.children[3].children.count).to eq(1)
         expect(foo.children[3].children[0].name).to eq("test_baz")
 
-        foo.children[4].inspect
-        STDERR.puts foo.children[4].children[0].name
+        expect(foo.children[4].name).to eq("日本語テスト")
         expect(foo.children[4].children[0].name).to eq("何かのテスト")
       end
     end

--- a/spec/ruby_lsp_rspec_spec.rb
+++ b/spec/ruby_lsp_rspec_spec.rb
@@ -235,6 +235,11 @@ RSpec.describe RubyLsp::RSpec do
 
           # unname test is ignored
           it { }
+
+          context "日本語テスト" do
+            it "何かのテスト" do
+            end
+          end
         end
       RUBY
 
@@ -257,27 +262,31 @@ RSpec.describe RubyLsp::RSpec do
         foo = response[0]
         expect(foo.name).to eq("Foo")
         expect(foo.kind).to eq(LanguageServer::Protocol::Constant::SymbolKind::MODULE)
-        expect(foo.children.count).to eq(4)
+        expect(foo.children.count).to eq(5)
 
-        expect(foo.children[0].name).to eq("\"when something\"")
+        expect(foo.children[0].name).to eq("when something")
         expect(foo.children[0].kind).to eq(LanguageServer::Protocol::Constant::SymbolKind::MODULE)
         expect(foo.children[0].children.count).to eq(1)
-        expect(foo.children[0].children[0].name).to eq("\"does something\"")
+        expect(foo.children[0].children[0].name).to eq("does something")
         expect(foo.children[0].children[0].kind).to eq(LanguageServer::Protocol::Constant::SymbolKind::METHOD)
 
         foo_bar = foo.children[1]
         expect(foo_bar.name).to eq("Foo::Bar")
         expect(foo_bar.children.count).to eq(2)
-        expect(foo_bar.children[0].name).to eq("\"does something else\"")
-        expect(foo_bar.children[1].name).to eq("\"when something else\"")
+        expect(foo_bar.children[0].name).to eq("does something else")
+        expect(foo_bar.children[1].name).to eq("when something else")
         expect(foo_bar.children[1].children.count).to eq(1)
-        expect(foo_bar.children[1].children[0].name).to eq("\"does something something\"")
+        expect(foo_bar.children[1].children[0].name).to eq("does something something")
 
         expect(foo.children[2].name).to eq("<variable>")
 
         expect(foo.children[3].name).to eq("Baz")
         expect(foo.children[3].children.count).to eq(1)
         expect(foo.children[3].children[0].name).to eq("test_baz")
+
+        foo.children[4].inspect
+        STDERR.puts foo.children[4].children[0].name
+        expect(foo.children[4].children[0].name).to eq("何かのテスト")
       end
     end
   end


### PR DESCRIPTION
Non-ASCII characters are shown with Unicode escape in symbol.

Creating name from Prism::StringNode uses context.dump function, so Non-ASCII characters are Unicode escape.

So I change `argument.content.dump` to [`argument.unescape`](https://docs.ruby-lang.org/en/master/Prism/StringNode.html#attribute-i-unescaped).

Due to this change, the double quotes between string are removed. So I change rspec also.
If you want to quote strings with double quote, I will fix it.

issue #42 