### PR TITLE
Disable ruby-lsp-rspec's definition listener outside test files

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
@@ -64,6 +64,8 @@ module RubyLsp
         ).void
       end
       def create_definition_listener(response_builder, uri, node_context, dispatcher)
+        return unless uri.to_standardized_path&.end_with?("_test.rb") || uri.to_standardized_path&.end_with?("_spec.rb")
+
         Definition.new(response_builder, uri, node_context, T.must(@index), dispatcher)
       end
 


### PR DESCRIPTION
Here is what happens when I add the addon
<img width="277" alt="Screenshot 2024-10-16 at 11 15 51" src="https://github.com/user-attachments/assets/29ef1147-0bf8-4f87-ab8b-80a63f7b24b0">
