### PR TITLE
Correct test IDs based on relative path

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
@@ -18,6 +18,7 @@ module RubyLsp
 
       def initialize(output)
         @output = output
+        @relative_path = ENV["RUBY_LSP_RSPEC_RELPATH"]
       end
 
       def example_started(notification)
@@ -59,7 +60,13 @@ module RubyLsp
       end
 
       def generate_id(example)
-        [example, *example.example_group.parent_groups].reverse.map(&:location).join("::")
+        [example, *example.example_group.parent_groups].reverse.map(&:location).map(&method(:make_relative)).join("::")
+      end
+
+      def make_relative(location)
+        return location unless @relative_path
+
+        location.sub(/^#{@relative_path}/, "./")
       end
     end
   end

--- a/spec/rspec_formatter_spec.rb
+++ b/spec/rspec_formatter_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 require "socket"
 require "open3"
 require "json"
+require_relative "../lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter"
 
 RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
   it "sends correct LSP events during test execution" do
@@ -134,5 +135,25 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
     ]
 
     expect(events).to eq(expected)
+  end
+
+  context "ID generation" do
+    before(:all) { @original_relpath = ENV["RUBY_LSP_RSPEC_RELPATH"] }
+    after { ENV["RUBY_LSP_RSPEC_RELPATH"] = @original_relpath }
+
+    it "generates the correct ID" do
+      formatter = RubyLsp::RSpec::RSpecFormatter.new(double("output"))
+
+      id = formatter.generate_id(RSpec.current_example)
+      expect(id).to match(%r{\.\/spec\/rspec_formatter_spec.rb:\d+::\.\/spec\/rspec_formatter_spec.rb:\d+})
+    end
+
+    it "strips a path prefix from test IDs" do
+      ENV["RUBY_LSP_RSPEC_RELPATH"] = "./spec/"
+      formatter = RubyLsp::RSpec::RSpecFormatter.new(double("output"))
+
+      id = formatter.generate_id(RSpec.current_example)
+      expect(id).to match(%r{\.\/rspec_formatter_spec.rb:\d+::\.\/rspec_formatter_spec.rb:\d+})
+    end
   end
 end


### PR DESCRIPTION
When running rspec from a parent directory the example's location used to generate the test IDs will not match how the tests are registered in the LSP.

By defining the envvar RUBY_LSP_RSPEC_RELPATH the path prefix will be removed for while generating the test IDs so that they align up.