### PR TITLE
Fix SpecStyle to not receive Prism events

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/spec_style_patch.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/spec_style_patch.rb
@@ -7,7 +7,7 @@ module RubyLsp
     class SpecStyle
       #: (ResponseBuilders::TestCollection, GlobalState, Prism::Dispatcher, URI::Generic) -> void
       def initialize(response_builder, global_state, dispatcher, uri)
-        super
+        # nop
       end
     end
   end

--- a/spec/spec_style_patch_spec.rb
+++ b/spec/spec_style_patch_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyLsp::Listeners::SpecStyle do
+  describe "spec_style_patch" do
+    it "disables initialization" do
+      RubyLsp::Listeners::SpecStyle.new(double("response_builder"), double("global_state"), double("dispatcher"), double("uri"))
+    end
+  end
+end


### PR DESCRIPTION
Calling super will still register for events. The parent class TestDiscovery [also registers](https://github.com/Shopify/ruby-lsp/blob/main/lib/ruby_lsp/listeners/test_discovery.rb#L20) SpecStyle for Prism event. While handling the events it tries to access a nil variable when entering a class or module and thus completely break code analysis of normal ruby files.

