### PR TITLE
Revert unintentional addon name change

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
@@ -46,7 +46,7 @@ module RubyLsp
       # @override
       #: -> String
       def name
-        "ruby-lsp-rspec"
+        "Ruby LSP RSpec"
       end
 
       # @override


### PR DESCRIPTION
In https://github.com/st0012/ruby-lsp-rspec/pull/62 I accidentally changed the addon's name, which would stop Ruby LSP from correctly fetching users' settings for the addon. This PR should fix it by reverting the name change.