### PR TITLE
Improved test failure message

### DIFF
--- a/spec/rspec_formatter_spec.rb
+++ b/spec/rspec_formatter_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
         "method" => "fail",
         "params" => {
           "id" => "./spec/fixtures/rspec_example_spec.rb:11::./spec/fixtures/rspec_example_spec.rb:12::./spec/fixtures/rspec_example_spec.rb:17",
-          "message" => "Failure/Error: expect(2).to eq(1)\n\n  expected: 1\n       got: 2\n\n  (compared using ==)\n\n# file://#{fixture_path}:18 : in `block (3 levels) in <top (required)>'",
+          "message" => %r{Failure/Error: expect\(2\).to eq\(1\)\n\n  expected: 1\n       got: 2\n\n  \(compared using ==\)\n\n# file://#{fixture_path}:18 : in [`']block \(3 levels\) in <top \(required\)>'},
           "uri" => "file://#{fixture_path}",
         },
       },
@@ -128,14 +128,14 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
         "method" => "fail",
         "params" => {
           "id" => "./spec/fixtures/rspec_example_spec.rb:11::./spec/fixtures/rspec_example_spec.rb:12::./spec/fixtures/rspec_example_spec.rb:30",
-          "message" => "Failure/Error: raise \"oops\"\n\nRuntimeError:\n  oops\n\n# file://#{fixture_path}:31 : in `block (3 levels) in <top (required)>'",
+          "message" => %r{Failure/Error: raise "oops"\n\nRuntimeError:\n  oops\n\n# file://#{fixture_path}:31 : in [`']block \(3 levels\) in <top \(required\)>'},
           "uri" => "file://#{fixture_path}",
         },
       },
       { "method" => "finish", "params" => {} },
     ]
 
-    expect(events).to eq(expected)
+    expect(events).to match(expected)
   end
 
   describe "RubyLsp::RSpec::RSpecFormatter notifications" do

--- a/spec/rspec_formatter_spec.rb
+++ b/spec/rspec_formatter_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
         "method" => "fail",
         "params" => {
           "id" => "./spec/fixtures/rspec_example_spec.rb:11::./spec/fixtures/rspec_example_spec.rb:12::./spec/fixtures/rspec_example_spec.rb:17",
-          "message" => "\nexpected: 1\n     got: 2\n\n(compared using ==)\n",
+          "message" => "Failure/Error: expect(2).to eq(1)\n\n  expected: 1\n       got: 2\n\n  (compared using ==)\n\n# file://#{fixture_path}:18 : in `block (3 levels) in <top (required)>'",
           "uri" => "file://#{fixture_path}",
         },
       },
@@ -128,7 +128,7 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
         "method" => "fail",
         "params" => {
           "id" => "./spec/fixtures/rspec_example_spec.rb:11::./spec/fixtures/rspec_example_spec.rb:12::./spec/fixtures/rspec_example_spec.rb:30",
-          "message" => "oops",
+          "message" => "Failure/Error: raise \"oops\"\n\nRuntimeError:\n  oops\n\n# file://#{fixture_path}:31 : in `block (3 levels) in <top (required)>'",
           "uri" => "file://#{fixture_path}",
         },
       },
@@ -175,8 +175,8 @@ RSpec.describe "RubyLsp::RSpec::RSpecFormatter" do
     end
 
     it "invokes ProgressFormatter's example_failed" do
-      exception = double("Exception", message: "error message")
-      allow(notification).to receive(:exception).and_return(exception)
+      allow(notification).to receive(:message_lines).and_return(["message lines"])
+      allow(notification).to receive(:formatted_backtrace).and_return(["spec/example_spec.rb:13:in `something'"])
 
       expect_any_instance_of(RSpec::Core::Formatters::ProgressFormatter).to receive(:example_failed)
 


### PR DESCRIPTION
The original test failure message only contained the assertion failure message which does not give a lot of information. Especially in larger test cases it can be difficult to find out which assertion failed. So I expanded the failure message to include all notification lines, which includes the assertion statement that failed and the relevant backtrace. The produced message is quite similar to the RSpec default message.

![image](https://github.com/user-attachments/assets/11202744-ef88-4999-96eb-b3601ff03c77)

I adjusted the path of the backtrace to a file URI which VSCode would pick up and allow you to quickly jump the relevant line in the test. This however does not work yet when using VSCode while developing on WSL, I logged an [issue with vscode](https://github.com/microsoft/vscode/issues/251076) for that. But at least this gives you the line number so you can manually navigate to it.