### PR TITLE
Handle starting tests for the whole project

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/addon.rb
@@ -116,8 +116,11 @@ module RubyLsp
           elsif tags.include?("test_group")
             start_line = item.dig(:range, :start, :line)
             commands << "#{@rspec_command} -r #{FORMATTER_PATH} -f #{FORMATTER_NAME} #{path}:#{start_line + 1}"
-          else
+          elsif tags.include?("test_case")
             full_files << "#{path}:#{item.dig(:range, :start, :line) + 1}"
+          else
+            # whole project
+            full_files << path
           end
 
           queue.concat(children)

--- a/spec/addon_spec.rb
+++ b/spec/addon_spec.rb
@@ -92,5 +92,33 @@ RSpec.describe RubyLsp::RSpec::Addon do
         ])
       end
     end
+
+    it "resolves commands for the whole project" do
+      project_uri = "file:///test-project"
+      with_server do |server|
+        server.process_message(
+          {
+            id: 1,
+            method: "rubyLsp/resolveTestCommands",
+            params: {
+              items: [
+                {
+                  id: project_uri,
+                  label: "test-project",
+                  tags: ["framework:rspec"],
+                  uri: project_uri,
+                  children: [],
+                },
+              ],
+            },
+          },
+        )
+
+        response = pop_result(server).response
+        expect(response[:commands]).to eq([
+          "bundle exec rspec -r #{formatter_absolute_path} -f #{formatter_name} /test-project",
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
If the tag is not a directory, file, group, or individual case, it is probably for the whole project. So use the path as test location.

Pressing this button in vscode should execute all test in the project.
![image](https://github.com/user-attachments/assets/a12011ef-98cc-447b-a2ac-4543b071e8d0)

This "item" does not contain any explicit tags unlike the other cases.