### PR TITLE
Fix testing with coverage

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
@@ -62,6 +62,9 @@ module RubyLsp
 
       def stop(notification)
         RubyLsp::LspReporter.instance.shutdown
+        if RubyLsp::LspReporter.start_coverage?
+          RubyLsp::LspReporter.instance.at_coverage_exit
+        end
       end
 
       def uri_for(example)

--- a/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/rspec_formatter.rb
@@ -61,9 +61,10 @@ module RubyLsp
       end
 
       def stop(notification)
-        RubyLsp::LspReporter.instance.shutdown
         if RubyLsp::LspReporter.start_coverage?
           RubyLsp::LspReporter.instance.at_coverage_exit
+        else
+          RubyLsp::LspReporter.instance.shutdown
         end
       end
 


### PR DESCRIPTION
When testing with coverage RubyLsp::LspReporter.instance.shutdown will not actually shutdown. It expects to be notified via at_coverage_exit so that it can gather coverage stats.