### PR TITLE
fix: only group specs if the `context` or `describe` call has a block

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -55,9 +55,11 @@ module RubyLsp
         puts "[#{self.class}]: #{message}"
       end
 
+      # A node is valid if it has a block and the receiver is RSpec (or nil)
       #: (Prism::CallNode) -> bool
       def valid_group?(node)
-        !(node.block.nil? || (node.receiver && node.receiver&.slice != "RSpec"))
+        return false if node.block.nil?
+        node.receiver.nil? || node.receiver&.slice == "RSpec"
       end
 
       #: (Prism::CallNode) -> String

--- a/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
@@ -30,6 +30,7 @@ module RubyLsp
 
         case node.message
         when "describe", "context"
+          return unless valid_group?(node)
           handle_describe(node)
         when "it", "specify", "example"
           handle_example(node)
@@ -116,9 +117,11 @@ module RubyLsp
         @group_stack.last
       end
 
+      # A node is valid if it has a block and the receiver is RSpec (or nil)
       #: (Prism::CallNode) -> bool
       def valid_group?(node)
-        !(node.block.nil? || (node.receiver && node.receiver&.slice != "RSpec"))
+        return false if node.block.nil?
+        node.receiver.nil? || node.receiver&.slice == "RSpec"
       end
 
       #: (Prism::CallNode) -> String


### PR DESCRIPTION
## The problem
If you have a spec with a `let` variable named one of the "reserved" words such as `context` or `describe` this gem interprets any usage of those variables as test group.  This breaks the VS Code integration since these aren't actually test groups and tests don't actually exist within them.

`context` is a pretty common and innocuous variable name so this causes a very large number of our specs to not work with this spec.

### To repro
Use this spec 
```ruby
RSpec.describe("Context bug") do
  let(:context) { "foo" }

  before do
    context
  end

  it("bar") { expect(true) }
end
```
Observe broken awareness of the spec, lack of code lens support, and incorrect labeling of the context variable as a spec.
<img width="821" height="400" alt="image" src="https://github.com/user-attachments/assets/4d84f01d-5fdc-4b3b-bb3a-9270e6db05e2" />


## The cause
There is a validation to see if a node is actually a test group, but it passes too easily.  It's treated as a node group even if there is no block associated with it.  In addition, there was no validation performed in `test_discovery`,

## The fix
Actually ensure the node has a block before allowing it to be treated as a test group.

### Behold
<img width="806" height="439" alt="image" src="https://github.com/user-attachments/assets/5eaf0a01-e442-46b8-9ee7-b16c011b25f8" />
