### PR TITLE
feat: add capybara keyword support

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/code_lens.rb
@@ -24,10 +24,10 @@ module RubyLsp
       #: (Prism::CallNode) -> void
       def on_call_node_enter(node)
         case node.message
-        when "example", "it", "specify"
+        when "example", "it", "specify", "scenario"
           name = generate_name(node)
           add_test_code_lens(node, name: name, kind: :example)
-        when "context", "describe"
+        when "context", "describe", "feature"
           return unless valid_group?(node)
 
           name = generate_name(node)
@@ -41,7 +41,7 @@ module RubyLsp
       #: (Prism::CallNode) -> void
       def on_call_node_leave(node)
         case node.message
-        when "context", "describe"
+        when "context", "describe", "feature"
           return unless valid_group?(node)
 
           @group_id_stack.pop

--- a/lib/ruby_lsp/ruby_lsp_rspec/document_symbol.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/document_symbol.rb
@@ -16,7 +16,7 @@ module RubyLsp
       #: (Prism::CallNode) -> void
       def on_call_node_enter(node)
         case node.message
-        when "example", "it", "specify"
+        when "example", "it", "specify", "scenario"
           name = generate_name(node)
 
           return unless name
@@ -27,7 +27,7 @@ module RubyLsp
             selection_range: range_from_node(node),
             range: range_from_node(node),
           )
-        when "context", "describe", "shared_examples", "shared_context", "shared_examples_for"
+        when "context", "describe", "shared_examples", "shared_context", "shared_examples_for", "feature", "scenario"
           return if node.receiver && node.receiver&.slice != "RSpec"
 
           name = generate_name(node)
@@ -50,7 +50,7 @@ module RubyLsp
       #: (Prism::CallNode) -> void
       def on_call_node_leave(node)
         case node.message
-        when "context", "describe", "shared_examples", "shared_context", "shared_examples_for"
+        when "context", "describe", "shared_examples", "shared_context", "shared_examples_for", "feature", "scenario"
           return if node.receiver && node.receiver&.slice != "RSpec"
 
           @response_builder.pop

--- a/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
@@ -26,12 +26,12 @@ module RubyLsp
 
       #: (Prism::CallNode) -> void
       def on_call_node_enter(node)
-        return unless ["describe", "context", "it", "specify", "example"].include?(node.message)
+        return unless ["describe", "context", "it", "specify", "example", "feature", "scenario"].include?(node.message)
 
         case node.message
-        when "describe", "context"
+        when "describe", "context", "feature"
           handle_describe(node)
-        when "it", "specify", "example"
+        when "it", "specify", "example", "scenario"
           handle_example(node)
         end
       end
@@ -39,7 +39,7 @@ module RubyLsp
       #: (Prism::CallNode) -> void
       def on_call_node_leave(node)
         case node.message
-        when "context", "describe"
+        when "context", "describe", "feature"
           return unless valid_group?(node)
 
           @group_stack.pop


### PR DESCRIPTION
This addresses #54 by adding support for "feature" and "scenario" which are aliases of "describe" and "it" respectively.  These come from the [capybara gem](https://github.com/teamcapybara/capybara#using-capybara-with-rspec)