### PR TITLE
Add trusted publisher workflow for automated gem releases

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,41 @@
+name: Publish gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'st0012/ruby-lsp-rspec'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: rubygems.org
+      url: https://rubygems.org/gems/ruby-lsp-rspec
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/push_gem.yml`) that automatically publishes the gem to rubygems.org when a version tag is pushed. Uses [trusted publishing](https://guides.rubygems.org/trusted-publishing/) with OIDC — no long-lived API keys needed.

Based on [RDoc's push_gem.yml](https://github.com/ruby/rdoc/blob/master/.github/workflows/push_gem.yml).

## New release flow

1. Bump version in `lib/ruby_lsp_rspec/version.rb`
2. `bundle install` to update Gemfile.lock
3. Commit and push to main
4. `git tag v<version> && git push --tags`
5. The workflow automatically publishes to rubygems.org and creates a GitHub release