### PR TITLE
fix: TestDiscovery items missing test_case/test_group tags causes Run in Terminal to run entire file

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_rspec/spec_style_patch.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/spec_style_patch.rb
@@ -11,4 +11,15 @@ module RubyLsp
       end
     end
   end
+
+  module Requests
+    module Support
+      class TestItem
+        #: (String) -> void
+        def add_tag(tag)
+          @tags << tag
+        end
+      end
+    end
+  end
 end

--- a/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
+++ b/lib/ruby_lsp/ruby_lsp_rspec/test_discovery.rb
@@ -84,6 +84,7 @@ module RubyLsp
           range_from_node(node),
           framework: :rspec,
         )
+        test_item.add_tag("test_group")
 
         if parent
           parent.add(test_item)
@@ -108,6 +109,7 @@ module RubyLsp
           range_from_node(node),
           framework: :rspec,
         )
+        test_item.add_tag("test_case")
 
         parent.add(test_item)
         @response_builder.add_code_lens(test_item)

--- a/spec/spec_style_patch_spec.rb
+++ b/spec/spec_style_patch_spec.rb
@@ -7,3 +7,28 @@ RSpec.describe RubyLsp::Listeners::SpecStyle do
     end
   end
 end
+
+RSpec.describe RubyLsp::Requests::Support::TestItem do
+  describe "#add_tag" do
+    it "appends a tag to the item's tags" do
+      item = described_class.new(
+        "some_id",
+        "some label",
+        URI("file:///fake_spec.rb"),
+        RubyLsp::Interface::Range.new(
+          start: RubyLsp::Interface::Position.new(line: 0, character: 0),
+          end: RubyLsp::Interface::Position.new(line: 0, character: 0),
+        ),
+        framework: :rspec,
+      )
+
+      expect(item.to_hash[:tags]).to eq(["framework:rspec"])
+
+      item.add_tag("test_case")
+      expect(item.to_hash[:tags]).to eq(["framework:rspec", "test_case"])
+
+      item.add_tag("test_group")
+      expect(item.to_hash[:tags]).to eq(["framework:rspec", "test_case", "test_group"])
+    end
+  end
+end

--- a/spec/test_discovery_spec.rb
+++ b/spec/test_discovery_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe RubyLsp::RSpec::TestDiscovery do
         first_group = items.first
         expect(first_group[:id]).to eq("./spec/fake_spec.rb:1")
         expect(first_group[:label]).to eq("Sample test")
+        expect(first_group[:tags]).to include("test_group")
         expect(first_group[:children].length).to eq(2)
 
         test_ids = first_group[:children].map { |i| i[:id] }
@@ -60,12 +61,16 @@ RSpec.describe RubyLsp::RSpec::TestDiscovery do
 
         test_labels = first_group[:children].map { |i| i[:label] }
         expect(test_labels).to include("first test")
-
         expect(test_labels).to include("second test")
+
+        first_group[:children].each do |child|
+          expect(child[:tags]).to include("test_case")
+        end
 
         second_group = items[1]
         expect(second_group[:id]).to eq("./spec/fake_spec.rb:11")
         expect(second_group[:label]).to eq("Foo")
+        expect(second_group[:tags]).to include("test_group")
         expect(second_group[:children].length).to eq(1)
 
         test_ids = second_group[:children].map { |i| i[:id] }
@@ -74,6 +79,7 @@ RSpec.describe RubyLsp::RSpec::TestDiscovery do
         third_group = items[2]
         expect(third_group[:id]).to eq("./spec/fake_spec.rb:17")
         expect(third_group[:label]).to eq("Foo::Bar")
+        expect(third_group[:tags]).to include("test_group")
         expect(third_group[:children].length).to eq(1)
 
         test_ids = third_group[:children].map { |i| i[:id] }
@@ -171,17 +177,22 @@ RSpec.describe RubyLsp::RSpec::TestDiscovery do
 
         outer_group = items.first
         expect(outer_group[:label]).to eq("Outer group")
+        expect(outer_group[:tags]).to include("test_group")
         expect(outer_group[:children].length).to eq(2)
 
         inner_groups = outer_group[:children]
         expect(inner_groups[0][:label]).to eq("Inner group")
+        expect(inner_groups[0][:tags]).to include("test_group")
         expect(inner_groups[1][:label]).to eq("Another group")
+        expect(inner_groups[1][:tags]).to include("test_group")
 
         expect(inner_groups[0][:children].length).to eq(1)
         expect(inner_groups[0][:children][0][:label]).to eq("nested test")
+        expect(inner_groups[0][:children][0][:tags]).to include("test_case")
 
         expect(inner_groups[1][:children].length).to eq(1)
         expect(inner_groups[1][:children][0][:label]).to eq("another test")
+        expect(inner_groups[1][:children][0][:tags]).to include("test_case")
       end
     end
 


### PR DESCRIPTION
## The problem

When clicking \"Run in Terminal\" on a specific test in the Test Explorer, the generated command runs the entire spec file instead of just that test.

`resolve_test_commands` ([link](https://github.com/st0012/ruby-lsp-rspec/blob/2b15887bfa4b93732f7774d9b479a0366962de84/lib/ruby_lsp/ruby_lsp_rspec/addon.rb#L91)) uses `test_case` and `test_group` tags to decide whether to include a line number in the command. But `TestDiscovery` never sets those tags — items only ever get `["framework:rspec"]`. So every item falls through to the `else` branch, which adds the full file path with no line number.

## Other options considered

**1. Fix the `else` branch in `resolve_test_commands`** — infer intent from structure: leaf nodes (no children) are test cases and should include a line number. This works but sidesteps the root cause and leaves the `test_case`/`test_group` branches as unreachable dead code.

**2. Add `add_tag` to `TestItem` in ruby-lsp** — the cleanest fix long-term, since `TestItem` is the right home for this and it would be part of the public addon API. The reason it doesn't exist is that the built-in Minitest listener lives inside ruby-lsp and can access `@tags` directly, so there was never pressure to expose it.

## Test plan
- [x] Added `test_group`/`test_case` tag assertions to `test_discovery_spec.rb`
- [x] Added `add_tag` test to `spec_style_patch_spec.rb`
- [x] `bundle exec srb tc` — no errors
- [x] `bundle exec rspec` — all examples pass